### PR TITLE
VShell C2 query

### DIFF
--- a/tracker.py
+++ b/tracker.py
@@ -222,6 +222,9 @@ def shodan():
         ],
         "Atlandida Stealer": [
             "http.title:'Atlantida' http.html:'GY7HXsD.jpg'"
+        ],
+        "Vshell C2": [
+            "http.title:'Vshell - 登录'"
         ]
     }
 


### PR DESCRIPTION
Hi! I've added a shodan query for vshell C2. I noticed it was missing. I think the Censys set of queries could use also `services.http.response.html_title: "Vshell - 登录"` :) let me know what you think. Thanks!
